### PR TITLE
Add random walk to candle mode

### DIFF
--- a/node-red/iotree-flows.json
+++ b/node-red/iotree-flows.json
@@ -811,7 +811,7 @@
                 "t": "set",
                 "p": "payload",
                 "pt": "msg",
-                "to": "{\"mode\":\"candle\",\"params\":{\"r\":100,\"g\":10,\"b\":0,\"period\":0.05,\"decay\":0.9,\"amp\":0.5,\"interval\":20,\"sparsity\":5}}",
+                "to": "{\"mode\":\"candle\",\"params\":{\"color\":{\"r\":100,\"g\":10,\"b\":0},\"sparsity\":5,\"flicker\":{\"prob\":0.002,\"decay\":0.9,\"amp\":0.5,\"interval\":20},\"period\":0.05,\"rand_walk\":{\"noise\":0.03,\"decay\":0.995}}}",
                 "tot": "json"
             }
         ],


### PR DESCRIPTION
And also refactor the candle state to be held in a class instance to capture the two-dimensional state, namely the `flicker` state and `rand_walk` state.